### PR TITLE
Fix WhoopsServiceProvider missing variables

### DIFF
--- a/src/Whoops/DebugbarHandler.php
+++ b/src/Whoops/DebugbarHandler.php
@@ -180,6 +180,7 @@ class DebugbarHandler extends Handler
         $templateFile = $this->getResource("views/layout.html.php");
         $cssFile      = $this->getResource("css/whoops.base.css");
         $zeptoFile    = $this->getResource("js/zepto.min.js");
+        $prettifyFile = $this->getResource("js/prettify.min.js");
         $clipboard    = $this->getResource("js/clipboard.min.js");
         $jsFile       = $this->getResource("js/whoops.base.js");
 
@@ -217,6 +218,7 @@ class DebugbarHandler extends Handler
             // @todo: Asset compiler
             "stylesheet" => file_get_contents($cssFile),
             "zepto"      => file_get_contents($zeptoFile),
+            "prettify"   => file_get_contents($prettifyFile),
             "clipboard"  => file_get_contents($clipboard),
             "javascript" => file_get_contents($jsFile),
 
@@ -236,6 +238,7 @@ class DebugbarHandler extends Handler
             "title"          => $this->getPageTitle(),
             "name"           => explode("\\", $inspector->getExceptionName()),
             "message"        => $inspector->getException()->getMessage(),
+            "previousMessages" => $inspector->getPreviousExceptionMessages(),
             "code"           => $code,
             "plain_exception" => Formatter::formatExceptionPlain($inspector),
             "frames"         => $frames,


### PR DESCRIPTION
Missing `$previousMessages` variable in `filp/whoops/src/Whoops/Resources/views/header.html.php` file and prettify js file.